### PR TITLE
Potential fix for code scanning alert no. 2: Permissive CORS configuration

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -24,8 +24,24 @@ const errorHandler = (err, req, res, next) => {
 };
 app.use(errorHandler);
 
+const allowedOrigins = (process.env.FRONTEND_URL || "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
 const corsOptions = {
-    origin: process.env.FRONTEND_URL || '*',
+    origin: (origin, callback) => {
+        // Allow non-browser or same-origin requests with no Origin header
+        if (!origin) {
+            return callback(null, true);
+        }
+
+        if (allowedOrigins.includes(origin)) {
+            return callback(null, true);
+        }
+
+        return callback(new Error("Not allowed by CORS"), false);
+    },
     methods: ['GET', 'POST'],
     allowedHeaders: ['Content-Type', 'Authorization'],
     credentials: true
@@ -45,7 +61,7 @@ app.use("/api/", limiter); // Apply rate-limiting to API routes
 
 const io = new Server(server, {
     cors: {
-        origin: process.env.FRONTEND_URL || "http://localhost:3000",
+        origin: allowedOrigins,
         methods: ["GET", "POST"]
     }
 });


### PR DESCRIPTION
Potential fix for [https://github.com/shivam-verma-19/log-analytics/security/code-scanning/2](https://github.com/shivam-verma-19/log-analytics/security/code-scanning/2)

Best fix: replace permissive CORS origin fallback with a strict allowlist-based origin validator and deny by default when the configured frontend URL is absent/invalid.

In `backend/server.js`, update the `corsOptions` block (around lines 27–33) so `origin` is a function that:
- Allows requests with no `Origin` header (non-browser/server-to-server use).
- Compares incoming origin against a sanitized allowlist derived from `process.env.FRONTEND_URL`.
- Rejects all others.
- Keeps existing methods/headers/credentials behavior unchanged.

Also apply the same allowlist logic to Socket.IO CORS config (lines 46–50), replacing direct `process.env.FRONTEND_URL || "http://localhost:3000"` with the same validated list. This addresses both alert variants and prevents broad/user-controlled origin behavior without changing intended functionality for a configured frontend URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
