### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,9 @@ on:
       - '**/package.json'
       - '**/package-lock.json'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/shivam-verma-19/log-analytics/security/code-scanning/3](https://github.com/shivam-verma-19/log-analytics/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained rather than inherited.  
Best single fix here: define workflow-level permissions right after the `on:` section (before `jobs:`), with `contents: read` as the minimal required scope for this workflow as indicated by the alert. This preserves current functionality while enforcing least privilege across all jobs in this file.

File to edit:
- `.github/workflows/codeql.yml`

Change needed:
- Insert:
  - `permissions:`
  - `  contents: read`

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
